### PR TITLE
Tuple header and implementation added

### DIFF
--- a/heron/api/src/cpp/tuple/Tuple.cpp
+++ b/heron/api/src/cpp/tuple/Tuple.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "Tuple.h"
+
+
+std::shared_ptr<Element> Tuple::Get(std::string name) {
+    return elements[name];
+}
+
+void Tuple::Set(std::string name, std::shared_ptr<Element> e) {
+    elements[name] = e;
+}
+
+void Tuple::serialize(IPluggableSerializer *Serializer, std::stringstream &ss) {
+    Serializer->serialize(ss, elements);
+}
+
+void Tuple::deserialize(IPluggableSerializer *Serializer, std::stringstream &ss) {
+    Serializer->deserialize(ss, elements);
+}

--- a/heron/api/src/cpp/tuple/Tuple.h
+++ b/heron/api/src/cpp/tuple/Tuple.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __HERON_TUPLE_H_
+#define __HERON_TUPLE_H_
+
+#include <sstream>
+#include "../types/types.h"
+#include "../serializer/IPluggableSerializer.h"
+
+class Tuple {
+    
+    std::map<std::string, std::shared_ptr<Element> > elements;
+
+public:
+
+    Tuple() {}
+
+    std::shared_ptr<Element>  Get(std::string name);
+    
+    void Set(std::string name, std::shared_ptr<Element> e);
+
+    void serialize(IPluggableSerializer *serializer, std::stringstream &ss);
+
+    void deserialize(IPluggableSerializer *serializer, std::stringstream &ss);
+
+};
+
+
+#endif


### PR DESCRIPTION
The skeleton of the final version of Tuple for the CPP API of Heron. 

In this version, I only use a map<String, Element>. However, in the Java version Twitter uses a double layer
List<string> + map<String, Element> to match the API I have to create the same.

In next versions I will port Fields and Values (two Java classes) and the final user will access to the tuples using the same API as in Java tuple.getValue(pos int);  